### PR TITLE
Entropy

### DIFF
--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -42,12 +42,11 @@ function entropy_shrinkage(counts::FrequencyWeights)
     # Uniform distribution
     t_k = 1 / length(θ_ML)
 
-    # Regularization parameter
     den = (n - 1) * sum((θ_ML - t_k) .^2)
-
     if den < 1e-10
       return entropy(ProbabilityWeights(θ_ML))
     else
+      # Regularization parameter
       λ = (1 - sum(θ_ML .^ 2)) / den
       return entropy(ProbabilityWeights(λ * t_k + (1 - λ) * θ_ML))
     end
@@ -69,7 +68,7 @@ end
 function estimate_joint_entropy(x::AbstractVector, y::AbstractVector; method::Symbol=:Naive)
   @assert length(x) == length(y) "Vectors must be the same length"
 
-  count_values = values(countmap([hash(y[i], hash(x[i])) for i=1:length(x)]))
-  freqs = FrequencyWeights(collect(count_values))
+  count = countmap([hash(yᵢ, hash(xᵢ)) for (xᵢ, yᵢ) ∈ zip(x, y)])
+  freqs = FrequencyWeights(collect(values(count)))
   entropy(freqs; method=method)
 end

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -43,11 +43,14 @@ function entropy_shrinkage(counts::FrequencyWeights)
     t_k = 1 / length(θ_ML)
 
     # Regularization parameter
-    λ = (1 - sum(θ_ML .^ 2)) / ((n - 1) * sum((θ_ML - t_k) .^2))
+    den = (n - 1) * sum((θ_ML - t_k) .^2)
 
-    isinf(λ) ?
-      entropy(ProbabilityWeights(θ_ML)) :
-      entropy(ProbabilityWeights(λ * t_k + (1 - λ) * θ_ML))
+    if den < 1e-10
+      return entropy(ProbabilityWeights(θ_ML))
+    else
+      λ = (1 - sum(θ_ML .^ 2)) / den
+      return entropy(ProbabilityWeights(λ * t_k + (1 - λ) * θ_ML))
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,63 +2,62 @@ using Discreet
 import StatsBase: FrequencyWeights, ProbabilityWeights
 using Base.Test
 
+freqs_uniform = FrequencyWeights([1, 1, 1, 1, 1, 1])
+probs_uniform = ProbabilityWeights([.5, .5])
+sample = [:a, :b, :c, :d, :e, :f]
 
-# Tests for entropy routines
+@testset "Entropy routines" begin
+    ## Naive estimator
+    @test log(6) ≈ entropy(freqs_uniform)
+    @test 0 == entropy(FrequencyWeights([6]))
+    @test log(6) ≈ estimate_entropy(sample)
 
-const freqs_uniform = FrequencyWeights([1, 1, 1, 1, 1, 1])
-const probs_uniform = ProbabilityWeights([.5, .5])
-const sample = [:a, :b, :c, :d, :e, :f]
+    ## CS and shrinkage estimates, from library(entropy) in R
+    @test 3.840549310406 ≈ entropy(FrequencyWeights([1,1,1,1,1,1]); method=:CS)
+    @test 2.201137101279 ≈ entropy(FrequencyWeights([4,2,3,2,4,2,1,1]); method=:CS)
+    @test 1.968382408728 ≈ entropy(FrequencyWeights([4,2,3,2,4,2,1,1]))
+    @test 2.379602895309 ≈ entropy(FrequencyWeights([4,2,3,0,2,4,0,0,2,1,1]);
+                                   method=:Shrink)
 
-## Naive estimator
-@test log(6) ≈ entropy(freqs_uniform)
-@test 0 == entropy(FrequencyWeights([6]))
-@test log(6) ≈ estimate_entropy(sample)
+    ## Any other method
+    @test_throws ArgumentError entropy(freqs_uniform; method=:NotImplemented)
+    @test_throws ArgumentError estimate_entropy(sample; method=:NotImplemented)
 
-## CS and shrinkage estimates, from library(entropy) in R
-@test 3.840549310406 ≈ entropy(FrequencyWeights([1,1,1,1,1,1]); method=:CS)
-@test 2.201137101279 ≈ entropy(FrequencyWeights([4,2,3,2,4,2,1,1]); method=:CS)
-@test 1.968382408728 ≈ entropy(FrequencyWeights([4,2,3,2,4,2,1,1]))
-@test 2.379602895309 ≈ entropy(FrequencyWeights([4,2,3,0,2,4,0,0,2,1,1]);
-                               method=:Shrink)
-
-## Any other method
-@test_throws ArgumentError entropy(freqs_uniform; method=:NotImplemented)
-@test_throws ArgumentError estimate_entropy(sample; method=:NotImplemented)
-
-## Joint entropy
-@test log(6) ≈ estimate_joint_entropy(sample, sample)
-@test 3.840549310406 ≈ estimate_joint_entropy(sample, sample; method=:CS)
-
-
-# Tests for mutual information routines
-
-const labels_a = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3]
-const labels_b = [1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2]
-
-mi = mutual_information(labels_a, labels_b)
-@test 0.41022 ≈ mi atol=1e-5
-
-e_a = estimate_entropy(labels_a)
-e_b = estimate_entropy(labels_b)
-mi_normalized = mutual_information(labels_a, labels_b; normalize=true)
-@test mi / min(e_a, e_b) ≈ mi_normalized
-
-data = hcat(sample, sample, sample)
-@test log(6) * ones(3, 3) ≈ mutual_information(data)
+    ## Joint entropy
+    @test log(6) ≈ estimate_joint_entropy(sample, sample)
+    @test 3.840549310406 ≈ estimate_joint_entropy(sample, sample; method=:CS)
+end
 
 
-# Tests for contingency tables
+@testset "Mutual information routines" begin
+    labels_a = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3]
+    labels_b = [1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2]
 
-d = rand(10, 10)
-table = d / sum(d)
-mi_1 = mutual_information_contingency(table)
-e_a, e_b =  entropy(sum(table, 1)), entropy(sum(table, 2))
-mi_2 = e_a + e_b - entropy(table[:])
-@test mi_1 ≈ mi_2
+    mi = mutual_information(labels_a, labels_b)
+    @test 0.41022 ≈ mi atol=1e-5
 
-## Normalized MI
-mi_norm = mutual_information_contingency(table; normalize=true)
-@test mi_norm ≈ mi_1 / min(e_a, e_b)
+    e_a = estimate_entropy(labels_a)
+    e_b = estimate_entropy(labels_b)
+    mi_normalized = mutual_information(labels_a, labels_b; normalize=true)
+    @test mi / min(e_a, e_b) ≈ mi_normalized
 
-## Table with no association
-@test 0 ≈ mutual_information_contingency(ones(20, 5) / 100) atol=1e-10
+    data = hcat(sample, sample, sample)
+    @test log(6) * ones(3, 3) ≈ mutual_information(data)
+end
+
+
+@testset "Contingency tables" begin
+    d = rand(10, 10)
+    table = d / sum(d)
+    mi_1 = mutual_information_contingency(table)
+    e_a, e_b =  entropy(sum(table, 1)), entropy(sum(table, 2))
+    mi_2 = e_a + e_b - entropy(table[:])
+    @test mi_1 ≈ mi_2
+
+    ## Normalized MI
+    mi_norm = mutual_information_contingency(table; normalize=true)
+    @test mi_norm ≈ mi_1 / min(e_a, e_b)
+
+    ## Table with no association
+    @test 0 ≈ mutual_information_contingency(ones(20, 5) / 100) atol=1e-10
+end


### PR DESCRIPTION
* modified the `entropy_shrinkage` to have an explicit case when things are likely to be "too big" instead of an `isinf` test. This could be improved (e.g.: to just check if the ratio is too big) ==> tests still passing (as per #1)
* modified the `estimate_joint_entropy` to use a `zip` of the vectors and some Julia niceties. No difference to be expected, just easier to read I think (?) ==> tests still passing
* modified the `runtests.jl` to put tests together using `@testset`, makes it a bit easier to see what's going on (also when running the tests). 

All in all these modifications are more cosmetic than anything else, rest looks good to me.